### PR TITLE
Add bower main configuration

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,9 @@
 {
   "name": "jquery-rotate",
   "version": "0.1.0",
+  "main": [
+  	"jquery.rotate.js"
+  ],
   "dependencies": {
     "jquery": ">=1.9.0"
   }


### PR DESCRIPTION
As per bower requirements.

Avoids an error while using jquery-rotate with grunt-wiredep.
